### PR TITLE
Add ndx-ophys-devices

### DIFF
--- a/ndx-ophys-devices/README.md
+++ b/ndx-ophys-devices/README.md
@@ -1,0 +1,3 @@
+# ndx-ophys-devices Extension for NWB:N
+
+This is a Neurodata Extension (NDX) for Neurodata Without Borders: Neurophysiology (NWB:N) 2.0 that provides an extension for storing metadata of devices used in optical experimental setup (microscopy, fiber photometry, optogenetic stimulation etc.)

--- a/ndx-ophys-devices/README.md
+++ b/ndx-ophys-devices/README.md
@@ -1,3 +1,3 @@
-# ndx-ophys-devices Extension for NWB:N
+# ndx-ophys-devices Extension for NWB
 
-This is a Neurodata Extension (NDX) for Neurodata Without Borders: Neurophysiology (NWB:N) 2.0 that provides an extension for storing metadata of devices used in optical experimental setup (microscopy, fiber photometry, optogenetic stimulation etc.)
+This is a Neurodata Extension (NDX) for Neurodata Without Borders (NWB) 2.0 that provides an extension for storing metadata of devices used in optical experimental setup (microscopy, fiber photometry, optogenetic stimulation etc.)

--- a/ndx-ophys-devices/ndx-meta.yaml
+++ b/ndx-ophys-devices/ndx-meta.yaml
@@ -1,0 +1,8 @@
+name: ndx-ophys-devices
+version: 0.1.0
+src: https://github.com/catalystneuro/ndx-ophys-devices
+pip:
+license: BSD
+maintainers:
+  - alessandratrapani
+


### PR DESCRIPTION
This is an NWB extension for storing metadata of devices used in optical experimental setup (microscopy, fiber photometry, optogenetic stimulation etc.)