### PR TITLE
Add main branch trigger to run_smithy workflow

### DIFF
--- a/.github/workflows/run_smithy.yml
+++ b/.github/workflows/run_smithy.yml
@@ -1,6 +1,8 @@
 name: Run smithy
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The run_smithy workflow should not run on my pushes to a branch or creation of a PR. This PR limits the workflow to run only on pushes to main.